### PR TITLE
Bootstrap 5 update

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -51,6 +51,29 @@
     font-size: 14px; /* default to 14px */
 }
 
+#headingWiki .accordion-button {
+    color: var(--medium-color);
+    background-color: var(--white);
+    padding-top: 0.5rem;
+    padding-right: 1rem;
+    padding-bottom: 0.5rem;
+    padding-left: 1rem;
+    font-size: 14px;
+}
+
+#wiki table {
+    table-layout:fixed;
+}
+
+#wiki table > tbody > tr > td {
+  word-wrap:break-word;
+  word-break:break-all;
+}
+
+#wiki section {
+    padding: 10px;
+}
+
 #wiki p, #wiki td[style*="font-size"] a {
    font-size: inherit;
 }

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -3,6 +3,7 @@
  *   */
 .concept-widget {
     border-top: 2px solid #394554;
+    background-color: #fff;
 }
 
 .concept-widget > .panel, .concept-widget #wiki {
@@ -14,6 +15,8 @@
 .concept-widget > .panel > #headingWiki {
     background-color: #fff;
 }
+
+.
 
 #collapseWiki > .panel-body > .btn:hover, #collapseWiki > .panel-body > .btn:active, #collapseWiki > .panel-body > .btn:focus {
     background-color: #fff;

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -64,11 +64,6 @@
 
 #wiki table > tbody > tr > td {
   word-wrap:break-word;
-  word-break:break-word;
-}
-
-#wiki table > tbody > tr {
-  word-wrap:break-word;
 }
 
 #wiki section {

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -62,13 +62,13 @@
     font-size: 14px;
 }
 
-#wiki table {
-    table-layout:fixed;
-}
-
 #wiki table > tbody > tr > td {
   word-wrap:break-word;
   word-break:break-word;
+}
+
+#wiki table > tbody > tr {
+  word-wrap:break-word;
 }
 
 #wiki section {
@@ -238,6 +238,10 @@
 #wiki table.wikitable th, #wiki table.wikitable td, #wiki table.prettytable th, #wiki table.prettytable td {
     border: 1px #aaa solid;
     padding: 0.2em;
+}
+
+#wiki #coordinates {
+    position: unset;
 }
 
 #collapseWiki .wikipedia-disclaimer {

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -4,6 +4,7 @@
 .concept-widget {
     border-top: 2px solid #394554;
     background-color: #fff;
+     margin-bottom: 20px;
 }
 
 .concept-widget > .panel, .concept-widget #wiki {
@@ -247,4 +248,3 @@
 #collapseWiki .wikipedia-credit {
     margin-top: 10px;
 }
-

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -68,7 +68,7 @@
 
 #wiki table > tbody > tr > td {
   word-wrap:break-word;
-  word-break:break-all;
+  word-break:break-word;
 }
 
 #wiki section {

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -54,9 +54,9 @@
 #headingWiki .accordion-button {
     color: var(--medium-color);
     background-color: var(--white);
-    padding-top: 0.5rem;
+    padding-top: 0.2rem;
     padding-right: 1rem;
-    padding-bottom: 0.5rem;
+    padding-bottom: 0.2rem;
     padding-left: 1rem;
     font-size: 14px;
 }

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -16,8 +16,6 @@
     background-color: #fff;
 }
 
-.
-
 #collapseWiki > .panel-body > .btn:hover, #collapseWiki > .panel-body > .btn:active, #collapseWiki > .panel-body > .btn:focus {
     background-color: #fff;
 }

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -55,11 +55,11 @@
 #headingWiki .accordion-button {
     color: var(--medium-color);
     background-color: var(--white);
-    padding-top: 0.2rem;
+    padding-top: 0.5rem;
     padding-right: 1rem;
-    padding-bottom: 0.2rem;
+    padding-bottom: 0.5rem;
     padding-left: 1rem;
-    font-size: 14px;
+    font-size: 1rem;
 }
 
 #wiki table > tbody > tr > td {

--- a/template.html
+++ b/template.html
@@ -2,11 +2,10 @@
     <div class="panel panel-default">
         <div class="panel-heading" role="tab" id="headingWiki">
             {{#if succeeded}}
-            <a class="collapsed" role="button" data-toggle="collapse" data-parent="#wikiAccordion" href="#collapseWiki" aria-expanded="false" aria-controls="collapseWiki">
-                <span class="glyphicon glyphicon-chevron-{{#if opened}}up{{else}}down{{/if}}{{#unless succeeded}} greyed-out{{/unless}}" aria-hidden="true"></span></a>
-            <a class="collapsed versal" role="button" data-toggle="collapse" data-parent="#wikiAccordion" href="#collapseWiki" aria-expanded="false" aria-controls="collapseWiki">
+            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseWiki" aria-expanded="true" aria-controls="collapseWiki">
                 {{wikipediaCaption}}
-            </a>{{#if wikipediaLang.diff}}({{wikipediaLang.value}}){{/if}}
+            </button>
+            {{#if wikipediaLang.diff}}({{wikipediaLang.value}}){{/if}}
             {{else}}
             {{wikipediaCaption}}
             {{/if}}

--- a/template.html
+++ b/template.html
@@ -2,7 +2,7 @@
     <div class="panel panel-default">
         <div class="panel-heading" role="tab" id="headingWiki">
             {{#if succeeded}}
-            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseWiki" aria-expanded="true" aria-controls="collapseWiki">
+            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseWiki" aria-expanded="true" aria-controls="collapseWiki">
                 {{wikipediaCaption}}
             </button>
             {{#if wikipediaLang.diff}}({{wikipediaLang.value}}){{/if}}
@@ -10,7 +10,7 @@
             {{wikipediaCaption}}
             {{/if}}
         </div>
-        <div id="collapseWiki" class="panel-collapse collapse{{#if opened}} in{{/if}}" role="tabpanel" aria-labelledby="headingWiki">
+        <div id="collapseWiki" class="panel-collapse collapse show" role="tabpanel" aria-labelledby="headingWiki">
             {{#if succeeded}}
             <div class="panel-body">
                 <div id="wiki" class="panel mw-parser-output" role="tabpanel" aria-labelledby="headingWikiWidget">

--- a/widget.js
+++ b/widget.js
@@ -140,18 +140,16 @@ WIKI = {
                     wikipediaURL: WIKI.wikipediaURL,
                     succeeded: true
                 });
-                // fix overwide tables and figures to support x-overflow
-                var wikiWidgetWidth = $("#wiki").width();
-                $.each($("#wiki table, #wiki figure"), function (i, elem) {
-                    if ($(this).width() > wikiWidgetWidth) {
-                        var temp2 = $("<div style='overflow-x:auto;'></div>");
+                // fix overwide tables
+                $.each($("#wiki table"), function (i, elem) {
+                    $(this).addClass("table");
+                        var temp2 = $("<div class='table-responsive-sm'></div>");
                         if (this.tagName === "FIGURE") {
                             temp2.css("margin-bottom", $(this).css("margin-bottom"));
                             this.style["margin-bottom"] = 0;
                         }
                         temp2.insertAfter($(this));
                         $(this).detach().appendTo(temp2);
-                    }
                 });
                 // fix overwide thumbinner classes
                 $.each($("#wiki .thumbinner"), function (i, elem) {


### PR DESCRIPTION
## Reasons for creating this PR

Bootstrap 5 Upgrade broke the layout for several Skosmos widgets, requiring an overhaul to several UI elements.

## Description of the changes in this PR

 - Fixed the collapsing element for the widget
 - Fixed the background
 - Padding added to the main text of the widget

## Known problems or uncertainties in this PR

 - Over-wide tables don't follow the width of the widget yet
